### PR TITLE
Changed replace url event from 'on_page_content' to 'on_post_page'

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,9 +26,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install dependecies
+      - name: Install dependencies
         shell: bash -l {0}
-        run: python3 -m pip install --no-build-isolation .[dev]
+        run: python3 -m pip install .[dev]
 
       - name: List installed packages
         shell: bash -l {0}

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ For example:
 
 | absolute URL | site_url | resulting URL |
 | --- | -------- | ------------- |
-| `/images/foo.png` | `https://example.com/` | `/images/foo.png` |
-| `/images/foo.png` | `https://example.com/subpage/` | `/subpage/images/foo.png` |
+| `/images/foo.png` | `https://example.com/` | `https://example.com/images/foo.png` |
+| `/images/foo.png` | `https://example.com/subpage/` | `https://example.com/subpage/images/foo.png` |
 
 ## Configuration
 

--- a/src/resolve_absolute_urls/plugin.py
+++ b/src/resolve_absolute_urls/plugin.py
@@ -31,17 +31,16 @@ class ResolveAbsoluteUrlsPlugin(mkdocs.plugins.BasePlugin[Config]):
         self._regex = re.compile(regex, re.IGNORECASE)
         return config
 
-    @mkdocs.plugins.event_priority(50)
-    def on_page_content(self, html, page, config, files):
+    def on_post_page(self, output, page, config):
         site_url = config["site_url"]
         if not site_url.endswith("/"):
             site_url += "/"
         path = urllib.parse.urlparse(site_url).path
+        
         def _replacer(match):
             attribute = match.group(1)
             url = match.group(3)
-
             logger.info(f"Replacing absolute url '{self.prefix}{url}' with '{path}{url}'")
             return f'{attribute}="{path}{url}"'
 
-        return self._regex.sub(_replacer, html)
+        return self._regex.sub(_replacer, output)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -122,7 +122,7 @@ def test_on_config_sets_regex(
     ],
     ids=["trailing_slash", "no_trailing_slash"],
 )
-def test_on_page_content(create_plugin, site_url):
+def test_on_post_page(create_plugin, site_url):
     """Test the on_page_content method of the ResolveAbsoluteUrlsPlugin."""
     plugin = create_plugin({
         "attributes": ["src", "data"],
@@ -131,8 +131,7 @@ def test_on_page_content(create_plugin, site_url):
     page = MagicMock()
     config = MagicMock()
     config.__getitem__.side_effect = lambda key: site_url if key == "site_url" else None
-    files = MagicMock()
-    html = '''
+    output = '''
     <img src  ="prefixexample.png" alt="Image">
     <img data =  \'prefix/image.png\'>
     <img data="site:docs/image.svg" class="example">
@@ -140,7 +139,7 @@ def test_on_page_content(create_plugin, site_url):
     '''
 
     plugin.on_config(config)
-    result = plugin.on_page_content(html, page, config, files)
+    result = plugin.on_post_page(output, page, config)
     expected_result = '''
     <img src="/docs/subpage/example.png" alt="Image">
     <img data="/docs/subpage//image.png">


### PR DESCRIPTION
Changed the plugin event for the url replacement to allow urls to be resolved even when they are inside templates rendered after the `on_page_content` event.

A successful test of the new functionality can be found in [this post](https://github.com/ACCESS-NRI/access-hive.org.au/pull/1013#issuecomment-3251283388).